### PR TITLE
Support Ameriabank comma-delimited CSV statements and add --no-terminal flag

### DIFF
--- a/internal/currency/currency.go
+++ b/internal/currency/currency.go
@@ -450,6 +450,9 @@ func convertToCurrency(
 
 			// Update the other currency if we found a better path.
 			otherNode := nodes[otherCurrency]
+			if otherNode == nil {
+				continue // Skip currencies not in the convertible set.
+			}
 			if newPrecision < otherNode.precision {
 				// Calculate converted amount based on exchange rate direction.
 				var newAmount model.MoneyWith2DecimalPlaces

--- a/internal/parser/ameria_csv_parser.go
+++ b/internal/parser/ameria_csv_parser.go
@@ -73,14 +73,21 @@ func (p AmeriaCsvFileParser) ParseRawTransactionsFromFile(
 		panic(err)
 	}
 
-	// Convert UTF-16 to UTF-8
-	utf8Data, err := decodeUTF16ToUTF8(fileData)
-	if err != nil {
-		panic(err)
+	// Detect encoding: UTF-16 LE files start with BOM 0xFF 0xFE.
+	var utf8Data []byte
+	delimiter := ','
+	if len(fileData) >= 2 && fileData[0] == 0xFF && fileData[1] == 0xFE {
+		utf8Data, err = decodeUTF16ToUTF8(fileData)
+		if err != nil {
+			panic(err)
+		}
+		delimiter = '\t'
+	} else {
+		utf8Data = fileData
 	}
 
 	reader := csv.NewReader(bytes.NewReader(utf8Data))
-	reader.Comma = '\t'         // Assuming the CSV is tab-delimited
+	reader.Comma = delimiter
 	reader.LazyQuotes = true    // Allow the reader to handle bare quotes
 	reader.FieldsPerRecord = -1 // Allow a variable number of fields per record
 

--- a/internal/parser/ameria_csv_parser.go
+++ b/internal/parser/ameria_csv_parser.go
@@ -196,8 +196,8 @@ func (p AmeriaCsvFileParser) ParseRawTransactionsFromFile(
 			RemitterBeneficiary: record[7],
 			Details:             record[4],
 		}
-		// If currency is not AMD then use credit and debit in AMD amounts.
-		if currency != "AMD" {
+		// If currency is not AMD and AMD columns are present, use AMD amounts.
+		if currency != "AMD" && withAmd {
 			var creditAmd, debitAmd model.MoneyWith2DecimalPlaces
 			if err := debitAmd.UnmarshalText([]byte(record[8])); err != nil {
 				return nil, fmt.Errorf("failed to parse debit(AMD) %v: %w", record, err)

--- a/internal/parser/ameria_csv_parser_test.go
+++ b/internal/parser/ameria_csv_parser_test.go
@@ -76,6 +76,54 @@ func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_BOMInHeader(t *testing
 	}
 }
 
+func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_CommaDelimited(t *testing.T) {
+	filePath := "testdata/ameria/comma_delimited.csv"
+	source := &model.TransactionsSource{
+		TypeName:        "AmeriaBank CSV statement",
+		Tag:             "AmeriaCsv:AMD",
+		FilePath:        filePath,
+		AccountNumber:   "1570048149171412",
+		AccountCurrency: "AMD",
+	}
+	transactions, err := AmeriaCsvFileParser{}.ParseRawTransactionsFromFile(filePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedTransactions := []model.Transaction{
+		{
+			IsExpense:       false,
+			Date:            time.Date(2026, time.January, 8, 0, 0, 0, 0, time.UTC),
+			Details:         "personal funds transfer",
+			Amount:          model.MoneyWith2DecimalPlaces{Cents: 10000000},
+			Source:          source,
+			AccountCurrency: "AMD",
+			FromAccount:     "1570048149171412",
+			ToAccount:       "1570048149171412",
+		},
+		{
+			IsExpense:       true,
+			Date:            time.Date(2026, time.January, 8, 0, 0, 0, 0, time.UTC),
+			Details:         "Ք: YEREVAN CITY AVAN YEREVAN AM 19",
+			Amount:          model.MoneyWith2DecimalPlaces{Cents: 202500},
+			Source:          source,
+			AccountCurrency: "AMD",
+			FromAccount:     "1570048149171412",
+			ToAccount:       "1570043102623434",
+		},
+	}
+
+	if len(transactions) != len(expectedTransactions) {
+		t.Fatalf("expected %d transactions, got %d", len(expectedTransactions), len(transactions))
+	}
+
+	for i, transaction := range transactions {
+		if diff := cmp.Diff(expectedTransactions[i], transaction, moneyComparer, diffOnlyTransformer); diff != "" {
+			t.Errorf("transaction %d mismatch (-expected +got):\n%s", i, diff)
+		}
+	}
+}
+
 func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_InvalidHeader(t *testing.T) {
 
 	// Act

--- a/internal/parser/ameria_csv_parser_test.go
+++ b/internal/parser/ameria_csv_parser_test.go
@@ -124,6 +124,40 @@ func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_CommaDelimited(t *test
 	}
 }
 
+func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_CommaDelimitedUSD(t *testing.T) {
+	filePath := "testdata/ameria/comma_delimited_usd.csv"
+	source := &model.TransactionsSource{
+		TypeName:        "AmeriaBank CSV statement",
+		Tag:             "AmeriaCsv:USD",
+		FilePath:        filePath,
+		AccountNumber:   "1570025188901801",
+		AccountCurrency: "USD",
+	}
+	transactions, err := AmeriaCsvFileParser{}.ParseRawTransactionsFromFile(filePath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(transactions) != 1 {
+		t.Fatalf("expected 1 transaction, got %d", len(transactions))
+	}
+
+	expected := model.Transaction{
+		IsExpense:       false,
+		Date:            time.Date(2024, time.May, 6, 0, 0, 0, 0, time.UTC),
+		Details:         "/ROC/5172400124JO///URI/PEERIDEA INC DBA ARC/PURPOSE/OTHR",
+		Amount:          model.MoneyWith2DecimalPlaces{Cents: 279000},
+		Source:          source,
+		AccountCurrency: "USD",
+		FromAccount:     "26867864",
+		ToAccount:       "1570025188901801",
+	}
+
+	if diff := cmp.Diff(expected, transactions[0], moneyComparer, diffOnlyTransformer); diff != "" {
+		t.Errorf("transaction mismatch (-expected +got):\n%s", diff)
+	}
+}
+
 func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_InvalidHeader(t *testing.T) {
 
 	// Act

--- a/internal/parser/ameria_csv_parser_test.go
+++ b/internal/parser/ameria_csv_parser_test.go
@@ -82,7 +82,7 @@ func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_CommaDelimited(t *test
 		TypeName:        "AmeriaBank CSV statement",
 		Tag:             "AmeriaCsv:AMD",
 		FilePath:        filePath,
-		AccountNumber:   "1570048149171412",
+		AccountNumber:   "9999999999999999",
 		AccountCurrency: "AMD",
 	}
 	transactions, err := AmeriaCsvFileParser{}.ParseRawTransactionsFromFile(filePath)
@@ -98,8 +98,8 @@ func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_CommaDelimited(t *test
 			Amount:          model.MoneyWith2DecimalPlaces{Cents: 10000000},
 			Source:          source,
 			AccountCurrency: "AMD",
-			FromAccount:     "1570048149171412",
-			ToAccount:       "1570048149171412",
+			FromAccount:     "9999999999999999",
+			ToAccount:       "9999999999999999",
 		},
 		{
 			IsExpense:       true,
@@ -108,8 +108,8 @@ func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_CommaDelimited(t *test
 			Amount:          model.MoneyWith2DecimalPlaces{Cents: 202500},
 			Source:          source,
 			AccountCurrency: "AMD",
-			FromAccount:     "1570048149171412",
-			ToAccount:       "1570043102623434",
+			FromAccount:     "9999999999999999",
+			ToAccount:       "8888888888888888",
 		},
 	}
 
@@ -130,7 +130,7 @@ func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_CommaDelimitedUSD(t *t
 		TypeName:        "AmeriaBank CSV statement",
 		Tag:             "AmeriaCsv:USD",
 		FilePath:        filePath,
-		AccountNumber:   "1570025188901801",
+		AccountNumber:   "7777777777777777",
 		AccountCurrency: "USD",
 	}
 	transactions, err := AmeriaCsvFileParser{}.ParseRawTransactionsFromFile(filePath)
@@ -145,12 +145,12 @@ func TestAmeriaCsvFileParser_ParseRawTransactionsFromFile_CommaDelimitedUSD(t *t
 	expected := model.Transaction{
 		IsExpense:       false,
 		Date:            time.Date(2024, time.May, 6, 0, 0, 0, 0, time.UTC),
-		Details:         "/ROC/5172400124JO///URI/PEERIDEA INC DBA ARC/PURPOSE/OTHR",
+		Details:         "/ROC/5172400124JO///URI/SOME COMPANY LLC/PURPOSE/OTHR",
 		Amount:          model.MoneyWith2DecimalPlaces{Cents: 279000},
 		Source:          source,
 		AccountCurrency: "USD",
 		FromAccount:     "26867864",
-		ToAccount:       "1570025188901801",
+		ToAccount:       "7777777777777777",
 	}
 
 	if diff := cmp.Diff(expected, transactions[0], moneyComparer, diffOnlyTransformer); diff != "" {

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ type Args struct {
 	ResultMode           string `arg:"-o" default:"web" help:"Specify how to open the result: 'none' for print into STDOUT only, 'web' for web server to see in browser, 'file' for opening result file in OS." enum:"none,web,file"`
 	DontBuildBeanconFile bool   `arg:"--no-beancount" help:"Flag to don't build Beancount file."`
 	DontBuildTextReport  bool   `arg:"--no-txt-report" help:"Flag to don't build TXT file report."`
-	NoTerminal           bool   `arg:"--no-terminal" help:"Run in the current terminal without opening external windows. Forces ResultMode to 'none'."`
+	NoTerminal           bool   `arg:"--no-terminal" help:"Run in the current terminal without opening a new terminal window. Skips EnsureTerminal even if configured."`
 }
 
 // Version is application version string and should be updated with `go build -ldflags`.
@@ -115,11 +115,6 @@ func runApplication(args Args) error {
 			return fmt.Errorf("error creating default config file: %w", err)
 		}
 		log.Printf("Created default config file at '%s'", args.ConfigPath)
-	}
-
-	// If --no-terminal is set, force ResultMode to "none" to avoid opening external windows.
-	if args.NoTerminal {
-		args.ResultMode = model.OPEN_MODE_NONE
 	}
 
 	// Validate ResultMode.

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ type Args struct {
 	ResultMode           string `arg:"-o" default:"web" help:"Specify how to open the result: 'none' for print into STDOUT only, 'web' for web server to see in browser, 'file' for opening result file in OS." enum:"none,web,file"`
 	DontBuildBeanconFile bool   `arg:"--no-beancount" help:"Flag to don't build Beancount file."`
 	DontBuildTextReport  bool   `arg:"--no-txt-report" help:"Flag to don't build TXT file report."`
+	NoTerminal           bool   `arg:"--no-terminal" help:"Run in the current terminal without opening external windows. Forces ResultMode to 'none'."`
 }
 
 // Version is application version string and should be updated with `go build -ldflags`.
@@ -116,6 +117,11 @@ func runApplication(args Args) error {
 		log.Printf("Created default config file at '%s'", args.ConfigPath)
 	}
 
+	// If --no-terminal is set, force ResultMode to "none" to avoid opening external windows.
+	if args.NoTerminal {
+		args.ResultMode = model.OPEN_MODE_NONE
+	}
+
 	// Validate ResultMode.
 	switch args.ResultMode {
 	case model.OPEN_MODE_NONE, model.OPEN_MODE_WEB, model.OPEN_MODE_FILE:
@@ -139,7 +145,7 @@ func runApplication(args Args) error {
 	}
 
 	// Ensure we're running in a terminal window before doing anything else.
-	if cfg.EnsureTerminal {
+	if cfg.EnsureTerminal && !args.NoTerminal {
 		platform.EnsureTerminalWindow()
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -139,6 +139,30 @@ func TestParseArgs_Success(t *testing.T) {
 			isHelpRequested: false,
 		},
 		{
+			name: "no-terminal flag",
+			args: []string{"--no-terminal"},
+			want: Args{
+				ConfigPath:           "config.yaml",
+				ResultMode:           "web",
+				DontBuildBeanconFile: false,
+				DontBuildTextReport:  false,
+				NoTerminal:           true,
+			},
+			isHelpRequested: false,
+		},
+		{
+			name: "no-terminal with explicit result mode",
+			args: []string{"--no-terminal", "-o", "file"},
+			want: Args{
+				ConfigPath:           "config.yaml",
+				ResultMode:           "file",
+				DontBuildBeanconFile: false,
+				DontBuildTextReport:  false,
+				NoTerminal:           true,
+			},
+			isHelpRequested: false,
+		},
+		{
 			name: "invalid result mode",
 			args: []string{"-o", "invalid"},
 			want: Args{

--- a/testdata/ameria/comma_delimited.csv
+++ b/testdata/ameria/comma_delimited.csv
@@ -1,0 +1,17 @@
+"Start of Period","","","01/04/2026"
+"End of Period","","","08/09/2026"
+"Account No.","","","1570048149171412","NAME SURNAME"
+"Currency","","","AMD","Armenian Dram"
+"TIN","","","12345678"
+
+"Opening Balance on 01/04/2026","","","0.00"
+"Debit Turnover","","","2,025.00"
+"Credit Turnover","","","100,000.00"
+"Closing Balance on 08/09/2026","","","100,500.99"
+"Closing Available Balance","","","100,500.99"
+
+Date,Doc.No.,Type,Account,Details,Debit,Credit,Remitter/Beneficiary,
+08/01/2026,000133,TRF,1570048149171412,personal funds transfer,0.00,"100,000.00",ՄԱԿdelays DELAYS ԱՁ,
+08/01/2026,218469,MSC,1570043102623434,Ք: YEREVAN CITY AVAN YEREVAN AM 19,"2,025.00",0.00,,
+
+"Days Count","","","161"

--- a/testdata/ameria/comma_delimited.csv
+++ b/testdata/ameria/comma_delimited.csv
@@ -1,6 +1,6 @@
 "Start of Period","","","01/04/2026"
 "End of Period","","","08/09/2026"
-"Account No.","","","1570048149171412","NAME SURNAME"
+"Account No.","","","9999999999999999","NAME SURNAME"
 "Currency","","","AMD","Armenian Dram"
 "TIN","","","12345678"
 
@@ -11,7 +11,7 @@
 "Closing Available Balance","","","100,500.99"
 
 Date,Doc.No.,Type,Account,Details,Debit,Credit,Remitter/Beneficiary,
-08/01/2026,000133,TRF,1570048149171412,personal funds transfer,0.00,"100,000.00",ՄԱԿdelays DELAYS ԱՁ,
-08/01/2026,218469,MSC,1570043102623434,Ք: YEREVAN CITY AVAN YEREVAN AM 19,"2,025.00",0.00,,
+08/01/2026,000133,TRF,9999999999999999,personal funds transfer,0.00,"100,000.00",ՄԱԿdelays DELAYS ԱՁ,
+08/01/2026,218469,MSC,8888888888888888,Ք: YEREVAN CITY AVAN YEREVAN AM 19,"2,025.00",0.00,,
 
 "Days Count","","","161"

--- a/testdata/ameria/comma_delimited_usd.csv
+++ b/testdata/ameria/comma_delimited_usd.csv
@@ -1,6 +1,6 @@
 "Start of Period","","","01/04/2024"
 "End of Period","","","08/09/2024"
-"Account No.","","","1570025188901801","NAME SURNAME"
+"Account No.","","","7777777777777777","NAME SURNAME"
 "Currency","","","USD","US Dollar"
 "TIN","","","12345678"
 
@@ -11,6 +11,6 @@
 "Closing Available Balance","","","2,790.00"
 
 Date,Doc.No.,Type,Account,Details,Debit,Credit,Remitter/Beneficiary,
-06/05/2024,0124JO,TRF,26867864,/ROC/5172400124JO///URI/PEERIDEA INC DBA ARC/PURPOSE/OTHR,0.00,"2,790.00",ALEKSANDR MAKAROV,
+06/05/2024,0124JO,TRF,26867864,/ROC/5172400124JO///URI/SOME COMPANY LLC/PURPOSE/OTHR,0.00,"2,790.00",ALEKSANDR MAKAROV,
 
 "Days Count","","","161"

--- a/testdata/ameria/comma_delimited_usd.csv
+++ b/testdata/ameria/comma_delimited_usd.csv
@@ -1,0 +1,16 @@
+"Start of Period","","","01/04/2024"
+"End of Period","","","08/09/2024"
+"Account No.","","","1570025188901801","NAME SURNAME"
+"Currency","","","USD","US Dollar"
+"TIN","","","12345678"
+
+"Opening Balance on 01/04/2024","","","0.00"
+"Debit Turnover","","","0.00"
+"Credit Turnover","","","2,790.00"
+"Closing Balance on 08/09/2024","","","2,790.00"
+"Closing Available Balance","","","2,790.00"
+
+Date,Doc.No.,Type,Account,Details,Debit,Credit,Remitter/Beneficiary,
+06/05/2024,0124JO,TRF,26867864,/ROC/5172400124JO///URI/PEERIDEA INC DBA ARC/PURPOSE/OTHR,0.00,"2,790.00",ALEKSANDR MAKAROV,
+
+"Days Count","","","161"


### PR DESCRIPTION
## Summary

Adds support for a second Ameriabank CSV export format — comma-delimited UTF-8 files that lack the `Debit(AMD)` / `Credit(AMD)` columns. Previously only tab-delimited UTF-16 exports (from the business banking portal) were supported. The new format is auto-detected by checking for the UTF-16 LE BOM (`0xFF 0xFE`).

Also adds a `--no-terminal` CLI flag for running the app directly in the current shell session, and fixes a crash in multi-currency conversion.

## Changes

### 1. Comma-delimited Ameriabank CSV support
Ameriabank exports account statements in two CSV formats:
- **Business portal**: UTF-16 LE, tab-delimited, optionally with `Debit(AMD)` / `Credit(AMD)` columns
- **Shortened format**: UTF-8, comma-delimited, 8 columns only (no AMD equivalents)

The parser now auto-detects encoding via the UTF-16 LE BOM and sets the CSV delimiter accordingly. No changes needed for the rest of the parsing logic since the column structure is identical.

### 2. Fix parsing non-AMD shortened CSVs
The existing code assumed that if the account currency wasn't AMD, the `Debit(AMD)` / `Credit(AMD)` columns would always be present. This caused a parse failure on shortened CSV files for USD/EUR accounts. Fixed by gating the AMD column access on both `currency != "AMD"` **and** `withAmd` (header declares those columns).

### 3. `--no-terminal` CLI flag
New `--no-terminal` flag skips the `EnsureTerminalWindow()` check, so the app runs in the invoking terminal instead of spawning a new OS terminal window. Useful for running from an existing shell, scripts, or CI.

### 4. Fix nil pointer dereference in currency conversion
The Dijkstra-based multi-hop currency converter could crash when an exchange rate edge referenced a currency not in the convertible set. Added a nil guard to skip such edges.

## Test plan
- [x] Existing Ameria CSV tests pass (UTF-16 tab-delimited with BOM)
- [x] New test: comma-delimited AMD file parses correctly
- [x] New test: comma-delimited USD file (no AMD columns) parses correctly
- [x] New tests: `--no-terminal` flag parsing
- [x] Full test suite passes