### PR TITLE
Fix nil pointer panic when converting currencies (fixes #13)

### DIFF
--- a/internal/currency/currency.go
+++ b/internal/currency/currency.go
@@ -265,6 +265,9 @@ func findClosestExchangeRateToCurrency(
 	targetCurrency string,
 	curState *currencyState,
 ) (*ExchangeRate, int) {
+	if curState == nil {
+		return nil, math.MaxInt
+	}
 	// If no exchange rates then return nil.
 	if len(curState.statistics.ExchangeRates) == 0 {
 		return nil, math.MaxInt
@@ -331,6 +334,9 @@ func convertToCurrency(
 
 	// Try to find direct exchange rate.
 	curState := curStates[amountCurrency]
+	if curState == nil {
+		return model.MoneyWith2DecimalPlaces{Cents: 0}, math.MaxInt, []string{}
+	}
 	exchangeRateDirect, daysDiffDirect := findClosestExchangeRateToCurrency(date, targetCurrency, curState)
 	if exchangeRateDirect != nil {
 		precision := daysDiffDirect
@@ -422,6 +428,9 @@ func convertToCurrency(
 
 		// Try all possible exchange rates from current currency to any other currency.
 		fromCurState := curStates[current.currency]
+		if fromCurState == nil {
+			continue
+		}
 		for _, er := range fromCurState.statistics.ExchangeRates {
 			// Get the other currency from the exchange rate.
 			otherCurrency := er.currencyTo
@@ -978,8 +987,18 @@ func BuildJournalEntries(
 ) ([]model.JournalEntry, []model.Transaction, error) {
 
 	// Make map of currencyState to speed up conversions.
-	curStates := make(map[string]*currencyState, len(dataMart.AllCurrencies))
+	// Use AllCurrencies for transaction-derived currencies, then merge
+	// ConvertibleCurrencies so config-only targets and fallback exchange rates
+	// are available when converting from any currency.
+	curStates := make(map[string]*currencyState, len(dataMart.AllCurrencies)+len(dataMart.ConvertibleCurrencies))
 	for currency, statistics := range dataMart.AllCurrencies {
+		curStates[currency] = &currencyState{
+			currency:                       currency,
+			statistics:                     statistics,
+			exchangeRateIndexesPerCurrency: make(map[string]int),
+		}
+	}
+	for currency, statistics := range dataMart.ConvertibleCurrencies {
 		curStates[currency] = &currencyState{
 			currency:                       currency,
 			statistics:                     statistics,

--- a/internal/currency/currency_test.go
+++ b/internal/currency/currency_test.go
@@ -647,37 +647,62 @@ func TestBuildDataMart_Issue13(t *testing.T) {
 // TestBuildJournalEntries_Issue13 documents outcomes for config + transaction input pairs.
 func TestBuildJournalEntries_Issue13(t *testing.T) {
 	tests := []struct {
-		name                    string
-		transactions            []model.Transaction
-		cfg                     *config.Config
-		removeFromAllCurrencies []string
-		wantPanic               bool
-		wantError               bool
+		name                            string
+		transactions                    []model.Transaction
+		cfg                             *config.Config
+		removeFromAllCurrencies         []string
+		removeFromConvertibleCurrencies []string
+		wantPanic                       bool
+		wantError                       bool
 	}{
 		{
 			// convertToCurrencies includes config-only RUB; transactions are AMD/USD only.
-			// Converting AMD/USD into RUB fails with an error, not a panic.
-			name:                    "config-only RUB target, AMD and USD transactions",
-			transactions:            issue13Transactions(false),
-			cfg:                     issue13Config(),
-			removeFromAllCurrencies: nil,
-			wantPanic:               false,
-			wantError:               true,
+			// Fallback rates from ConvertibleCurrencies are now available in curStates.
+			name:                            "config-only RUB target, AMD and USD transactions",
+			transactions:                    issue13Transactions(false),
+			cfg:                             issue13Config(),
+			removeFromAllCurrencies:         nil,
+			removeFromConvertibleCurrencies: nil,
+			wantPanic:                       false,
+			wantError:                       false,
 		},
 		{
 			// RUB appears on a transaction row, so BuildDataMart keeps RUB in AllCurrencies.
-			name:                    "RUB in config and on transaction rows",
-			transactions:            issue13Transactions(true),
-			cfg:                     issue13Config(),
-			removeFromAllCurrencies: nil,
-			wantPanic:               false,
-			wantError:               false,
+			name:                            "RUB in config and on transaction rows",
+			transactions:                    issue13Transactions(true),
+			cfg:                             issue13Config(),
+			removeFromAllCurrencies:         nil,
+			removeFromConvertibleCurrencies: nil,
+			wantPanic:                       false,
+			wantError:                       false,
 		},
 		{
-			// Panic condition: a row has AccountCurrency=RUB (convert FROM RUB), but RUB is
-			// absent from AllCurrencies/curStates. BuildDataMart normally prevents this;
-			// convertToCurrency must not dereference a missing curState.
-			name: "RUB transaction row with RUB missing from AllCurrencies",
+			// RUB removed from AllCurrencies but still present in ConvertibleCurrencies
+			// with config fallback rates — conversion succeeds without panic.
+			name: "RUB transaction row with RUB missing from AllCurrencies only",
+			transactions: []model.Transaction{{
+				Date:            time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+				AccountCurrency: "RUB",
+				Amount:          model.MoneyWith2DecimalPlaces{Cents: 800000},
+				Details:         "RUB expense",
+				FromAccount:     "acc-rub",
+				ToAccount:       "exp1",
+				IsExpense:       true,
+				Source:          &model.TransactionsSource{TypeName: "Ameria", FilePath: "history.csv"},
+			}},
+			cfg: func() *config.Config {
+				cfg := issue13Config()
+				cfg.ConvertToCurrencies = []string{"AMD", "USD", "RUB"}
+				return cfg
+			}(),
+			removeFromAllCurrencies:         []string{"RUB"},
+			removeFromConvertibleCurrencies: nil,
+			wantPanic:                       false,
+			wantError:                       false,
+		},
+		{
+			// Source currency absent from both currency maps must return a conversion error, not panic.
+			name: "RUB transaction row with RUB missing from all curStates sources",
 			transactions: []model.Transaction{{
 				Date:            time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
 				AccountCurrency: "RUB",
@@ -693,9 +718,10 @@ func TestBuildJournalEntries_Issue13(t *testing.T) {
 				cfg.ConvertToCurrencies = []string{"AMD", "USD"}
 				return cfg
 			}(),
-			removeFromAllCurrencies: []string{"RUB"},
-			wantPanic:               true,
-			wantError:               false,
+			removeFromAllCurrencies:         []string{"RUB"},
+			removeFromConvertibleCurrencies: []string{"RUB"},
+			wantPanic:                       false,
+			wantError:                       true,
 		},
 	}
 	for _, test := range tests {
@@ -711,6 +737,9 @@ func TestBuildJournalEntries_Issue13(t *testing.T) {
 			}
 			for _, currency := range test.removeFromAllCurrencies {
 				delete(dataMart.AllCurrencies, currency)
+			}
+			for _, currency := range test.removeFromConvertibleCurrencies {
+				delete(dataMart.ConvertibleCurrencies, currency)
 			}
 
 			var panicValue any
@@ -740,18 +769,12 @@ func TestBuildJournalEntries_Issue13(t *testing.T) {
 	}
 }
 
-// TestConvertToCurrency_Issue13 is the minimal reproduction of the nil dereference:
-// convert FROM a currency that is not present in curStates.
+// TestConvertToCurrency_Issue13 verifies convertToCurrency handles a missing source
+// currency in curStates without panicking.
 func TestConvertToCurrency_Issue13(t *testing.T) {
 	rateDate := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
 
-	defer func() {
-		if recover() == nil {
-			t.Fatal("expected panic when amountCurrency is missing from curStates")
-		}
-	}()
-
-	convertToCurrency(
+	amount, precision, path := convertToCurrency(
 		model.MoneyWith2DecimalPlaces{Cents: 800000},
 		"RUB",
 		"AMD",
@@ -768,6 +791,16 @@ func TestConvertToCurrency_Issue13(t *testing.T) {
 			},
 		},
 	)
+
+	if amount.Cents != 0 {
+		t.Fatalf("expected zero converted amount, got %d", amount.Cents)
+	}
+	if precision != math.MaxInt {
+		t.Fatalf("expected precision %d, got %d", math.MaxInt, precision)
+	}
+	if len(path) != 0 {
+		t.Fatalf("expected empty conversion path, got %v", path)
+	}
 }
 
 func assertCurrencyNames(t *testing.T, mapName string, currencies map[string]*CurrencyStatistics, want []string) {

--- a/internal/currency/currency_test.go
+++ b/internal/currency/currency_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
+	"github.com/AlexanderMakarov/am-budget-view/internal/categorization"
 	"github.com/AlexanderMakarov/am-budget-view/internal/config"
 	"github.com/AlexanderMakarov/am-budget-view/internal/model"
 )
@@ -533,6 +535,252 @@ func TestConvertToCurrency(t *testing.T) {
 				t.Errorf("Expected path %+v, got %+v", test.expectedPath, actualPath)
 			}
 		})
+	}
+}
+
+func issue13Config() *config.Config {
+	return &config.Config{
+		ExchangeRates: map[string]map[string]float64{
+			"USD": {"AMD": 380, "EUR": 0.86, "RUB": 80},
+		},
+		ConvertToCurrencies: []string{"AMD", "USD", "RUB"},
+		Groups: map[string]*config.GroupConfig{
+			"expense": {Substrings: []string{"expense", "payment"}},
+		},
+	}
+}
+
+func issue13Transactions(includeRUB bool) []model.Transaction {
+	source := &model.TransactionsSource{TypeName: "Ameria", FilePath: "history.csv"}
+	transactions := []model.Transaction{
+		{
+			Date:            time.Date(2025, 10, 1, 0, 0, 0, 0, time.UTC),
+			AccountCurrency: "AMD",
+			Amount:          model.MoneyWith2DecimalPlaces{Cents: 100000},
+			Details:         "AMD expense",
+			FromAccount:     "acc-amd",
+			ToAccount:       "exp1",
+			IsExpense:       true,
+			Source:          source,
+		},
+		{
+			Date:            time.Date(2025, 10, 2, 0, 0, 0, 0, time.UTC),
+			AccountCurrency: "USD",
+			Amount:          model.MoneyWith2DecimalPlaces{Cents: 10000},
+			Details:         "USD expense",
+			FromAccount:     "acc-usd",
+			ToAccount:       "exp1",
+			IsExpense:       true,
+			Source:          source,
+		},
+	}
+	if includeRUB {
+		transactions = append(transactions, model.Transaction{
+			Date:            time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+			AccountCurrency: "RUB",
+			Amount:          model.MoneyWith2DecimalPlaces{Cents: 800000},
+			Details:         "RUB expense",
+			FromAccount:     "acc-rub",
+			ToAccount:       "exp1",
+			IsExpense:       true,
+			Source:          source,
+		})
+	}
+	return transactions
+}
+
+// TestBuildDataMart_Issue13 documents how config and transaction inputs populate
+// AllCurrencies vs ConvertibleCurrencies (https://github.com/AlexanderMakarov/am-budget-view/issues/13).
+func TestBuildDataMart_Issue13(t *testing.T) {
+	tests := []struct {
+		name                       string
+		includeRUBInTransactions   bool
+		wantAllCurrencies          []string
+		wantConvertibleCurrencies  []string
+		wantRUBInAllCurrencies     bool
+		wantRUBInConvertible       bool
+	}{
+		{
+			// Config lists RUB as a conversion target; transactions only have AMD/USD rows
+			// with no embedded exchange-rate pairs. RUB is config-only: it lands in
+			// ConvertibleCurrencies (with fallback rates) but not in AllCurrencies.
+			name:                      "config lists RUB, transactions have AMD and USD only",
+			includeRUBInTransactions:  false,
+			wantAllCurrencies:         []string{"AMD", "USD"},
+			wantConvertibleCurrencies: []string{"AMD", "USD", "RUB"},
+			wantRUBInAllCurrencies:    false,
+			wantRUBInConvertible:      true,
+		},
+		{
+			// Same config, but a transaction row uses AccountCurrency=RUB.
+			// RUB is collected from transactions and appears in both maps.
+			name:                      "config lists RUB, transactions include RUB account rows",
+			includeRUBInTransactions:  true,
+			wantAllCurrencies:         []string{"AMD", "USD", "RUB"},
+			wantConvertibleCurrencies: []string{"AMD", "USD", "RUB"},
+			wantRUBInAllCurrencies:    true,
+			wantRUBInConvertible:      true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dataMart, err := BuildDataMart(issue13Transactions(test.includeRUBInTransactions), issue13Config())
+			if err != nil {
+				t.Fatalf("BuildDataMart: %v", err)
+			}
+
+			assertCurrencyNames(t, "AllCurrencies", dataMart.AllCurrencies, test.wantAllCurrencies)
+			assertCurrencyNames(t, "ConvertibleCurrencies", dataMart.ConvertibleCurrencies, test.wantConvertibleCurrencies)
+
+			_, rubInAll := dataMart.AllCurrencies["RUB"]
+			_, rubInConvertible := dataMart.ConvertibleCurrencies["RUB"]
+			if rubInAll != test.wantRUBInAllCurrencies {
+				t.Fatalf("RUB in AllCurrencies = %v, want %v", rubInAll, test.wantRUBInAllCurrencies)
+			}
+			if rubInConvertible != test.wantRUBInConvertible {
+				t.Fatalf("RUB in ConvertibleCurrencies = %v, want %v", rubInConvertible, test.wantRUBInConvertible)
+			}
+		})
+	}
+}
+
+// TestBuildJournalEntries_Issue13 documents outcomes for config + transaction input pairs.
+func TestBuildJournalEntries_Issue13(t *testing.T) {
+	tests := []struct {
+		name                    string
+		transactions            []model.Transaction
+		cfg                     *config.Config
+		removeFromAllCurrencies []string
+		wantPanic               bool
+		wantError               bool
+	}{
+		{
+			// convertToCurrencies includes config-only RUB; transactions are AMD/USD only.
+			// Converting AMD/USD into RUB fails with an error, not a panic.
+			name:                    "config-only RUB target, AMD and USD transactions",
+			transactions:            issue13Transactions(false),
+			cfg:                     issue13Config(),
+			removeFromAllCurrencies: nil,
+			wantPanic:               false,
+			wantError:               true,
+		},
+		{
+			// RUB appears on a transaction row, so BuildDataMart keeps RUB in AllCurrencies.
+			name:                    "RUB in config and on transaction rows",
+			transactions:            issue13Transactions(true),
+			cfg:                     issue13Config(),
+			removeFromAllCurrencies: nil,
+			wantPanic:               false,
+			wantError:               false,
+		},
+		{
+			// Panic condition: a row has AccountCurrency=RUB (convert FROM RUB), but RUB is
+			// absent from AllCurrencies/curStates. BuildDataMart normally prevents this;
+			// convertToCurrency must not dereference a missing curState.
+			name: "RUB transaction row with RUB missing from AllCurrencies",
+			transactions: []model.Transaction{{
+				Date:            time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC),
+				AccountCurrency: "RUB",
+				Amount:          model.MoneyWith2DecimalPlaces{Cents: 800000},
+				Details:         "RUB expense",
+				FromAccount:     "acc-rub",
+				ToAccount:       "exp1",
+				IsExpense:       true,
+				Source:          &model.TransactionsSource{TypeName: "Ameria", FilePath: "history.csv"},
+			}},
+			cfg: func() *config.Config {
+				cfg := issue13Config()
+				cfg.ConvertToCurrencies = []string{"AMD", "USD"}
+				return cfg
+			}(),
+			removeFromAllCurrencies: []string{"RUB"},
+			wantPanic:               true,
+			wantError:               false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cat, err := categorization.NewCategorization(test.cfg)
+			if err != nil {
+				t.Fatalf("NewCategorization: %v", err)
+			}
+
+			dataMart, err := BuildDataMart(test.transactions, test.cfg)
+			if err != nil {
+				t.Fatalf("BuildDataMart: %v", err)
+			}
+			for _, currency := range test.removeFromAllCurrencies {
+				delete(dataMart.AllCurrencies, currency)
+			}
+
+			var panicValue any
+			func() {
+				defer func() {
+					panicValue = recover()
+				}()
+				_, _, err = BuildJournalEntries(dataMart, cat)
+			}()
+
+			if test.wantPanic {
+				if panicValue == nil {
+					t.Fatal("expected panic when converting from a currency missing from AllCurrencies")
+				}
+				return
+			}
+			if panicValue != nil {
+				t.Fatalf("unexpected panic: %v", panicValue)
+			}
+			if test.wantError && err == nil {
+				t.Fatal("expected conversion error, got nil")
+			}
+			if !test.wantError && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestConvertToCurrency_Issue13 is the minimal reproduction of the nil dereference:
+// convert FROM a currency that is not present in curStates.
+func TestConvertToCurrency_Issue13(t *testing.T) {
+	rateDate := time.Date(2026, 4, 16, 0, 0, 0, 0, time.UTC)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic when amountCurrency is missing from curStates")
+		}
+	}()
+
+	convertToCurrency(
+		model.MoneyWith2DecimalPlaces{Cents: 800000},
+		"RUB",
+		"AMD",
+		rateDate,
+		map[string]*currencyState{
+			"USD": {
+				currency: "USD",
+				statistics: &CurrencyStatistics{
+					ExchangeRates: []*ExchangeRate{
+						{date: rateDate, currencyFrom: "USD", currencyTo: "AMD", exchangeRate: 1.0 / 380},
+					},
+				},
+				exchangeRateIndexesPerCurrency: map[string]int{},
+			},
+		},
+	)
+}
+
+func assertCurrencyNames(t *testing.T, mapName string, currencies map[string]*CurrencyStatistics, want []string) {
+	t.Helper()
+	got := make([]string, 0, len(currencies))
+	for name := range currencies {
+		got = append(got, name)
+	}
+	slices.Sort(got)
+	wantSorted := append([]string(nil), want...)
+	slices.Sort(wantSorted)
+	if !reflect.DeepEqual(got, wantSorted) {
+		t.Fatalf("%s currencies = %v, want %v", mapName, got, wantSorted)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds regression tests for [issue #13](https://github.com/AlexanderMakarov/am-budget-view/issues/13): documents how `convertToCurrencies` config and transaction currencies populate `AllCurrencies` vs `ConvertibleCurrencies`, and covers the nil dereference in `convertToCurrency`.
- Fixes the panic by building `curStates` from both `AllCurrencies` and `ConvertibleCurrencies`, so config fallback exchange rates are available during conversion.
- Adds nil guards in `convertToCurrency` and `findClosestExchangeRateToCurrency` so a missing source currency returns a conversion error instead of crashing.

## Test plan
- [x] `go test ./internal/currency/ -run Issue13`
- [x] `go test ./...`